### PR TITLE
Include the test suite in the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,6 @@ include MANIFEST.in
 recursive-include repoze *
 
 recursive-exclude docs *
-recursive-exclude tests *
+recursive-include tests *
 
 global-exclude *~ *.pyc *.egg .directory


### PR DESCRIPTION
It's good to include the testsuite in the release tarball so that downstream packagers can make sure that the tests pass on their system when they've packaged it up.  The tests won't go into the library when the sdist is then built, just into the sist tarball itself.
